### PR TITLE
Win compatibility for basic example

### DIFF
--- a/bonsai/bonsai_main.py
+++ b/bonsai/bonsai_main.py
@@ -14,6 +14,17 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 os.chdir(parent_dir)
 
+if sys.platform == "win32":
+    import types
+    m = types.ModuleType("resource")
+    m.RLIMIT_AS = 0
+    m.RUSAGE_SELF = 0
+    m.getrusage = lambda x: types.SimpleNamespace(
+        ru_maxrss=0, ru_utime=0, ru_stime=0
+    )
+    m.setrlimit = lambda x, y: None
+    sys.modules["resource"] = m
+
 from bonsai.bonsai_helpers import Run_Configs, remove_tree_folders, find_latest_tree_folder_new, str2bool, \
     store_scdata_and_communicate_path
 

--- a/bonsai_scout/app.py
+++ b/bonsai_scout/app.py
@@ -1,1 +1,14 @@
-bonsai_scout_app.py
+import sys
+
+if sys.platform == "win32":
+    import types
+    m = types.ModuleType("resource")
+    m.RLIMIT_AS = 0
+    m.RUSAGE_SELF = 0
+    m.getrusage = lambda x: types.SimpleNamespace(
+        ru_maxrss=0, ru_utime=0, ru_stime=0
+    )
+    m.setrlimit = lambda x, y: None
+    sys.modules["resource"] = m
+
+from bonsai_scout_app import app

--- a/bonsai_scout/bonsai_scout_helpers.py
+++ b/bonsai_scout/bonsai_scout_helpers.py
@@ -1,11 +1,11 @@
 import numpy as np
 from scipy import optimize
 import pandas as pd
+import matplotlib
+matplotlib.use('Agg')  # Set non-interactive backend for web apps
 import matplotlib.pyplot as plt
 
 plt.set_loglevel(level='warning')
-
-import matplotlib
 import re
 import itertools
 import time

--- a/bonsai_scout/bonsai_scout_helpers.py
+++ b/bonsai_scout/bonsai_scout_helpers.py
@@ -47,6 +47,19 @@ logger = logging.getLogger("myapp")
 logger.setLevel(log_level)
 
 
+def _json_safe(value):
+    """Recursively convert NumPy objects to plain Python JSON-safe types."""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
 class Celltype_info:
     annot_alts = None
     annot_infos = None
@@ -432,7 +445,7 @@ class Bonvis_settings:
         self.upd_edge_coords = {}
 
     def to_json(self, settings_path):
-        self_dict = self.to_dict()
+        self_dict = _json_safe(self.to_dict())
         with open(settings_path, "w") as json_file:
             logger.info("Storing settings in {}.".format(settings_path))
             json.dump(self_dict, json_file, indent=4)

--- a/bonsai_scout/bonsai_scout_preprocess.py
+++ b/bonsai_scout/bonsai_scout_preprocess.py
@@ -26,6 +26,17 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(parent_dir)
 os.chdir(parent_dir)
 
+if sys.platform == "win32":
+    import types
+    m = types.ModuleType("resource")
+    m.RLIMIT_AS = 0
+    m.RUSAGE_SELF = 0
+    m.getrusage = lambda x: types.SimpleNamespace(
+        ru_maxrss=0, ru_utime=0, ru_stime=0
+    )
+    m.setrlimit = lambda x, y: None
+    sys.modules["resource"] = m
+
 from bonsai.bonsai_helpers import str2bool, Run_Configs, find_latest_tree_folder, mp_print
 from downstream_analyses.get_clusters_max_diameter import get_min_pdists_clustering_from_nwk_str, \
     get_cluster_assignments, get_annotation_based_clustering_from_nwk_str


### PR DESCRIPTION
1. `resource` package does not apparently exist for Windows. Proper fix is to switch to `psutils`, here is only a workaround setting dummy module to be able to run the code

```
if sys.platform == "win32":
    import types
    m = types.ModuleType("resource")
    m.RLIMIT_AS = 0
    m.RUSAGE_SELF = 0
    m.getrusage = lambda x: types.SimpleNamespace(
        ru_maxrss=0, ru_utime=0, ru_stime=0
    )
    m.setrlimit = lambda x, y: None
    sys.modules["resource"] = m
```

2. Removed symbolic link in the `bonsai_cout/app.py` which breaks on Win and replaced with
`from bonsai_scout_app import app`

3. Fix json serialization of some array in `bonsai_scout/bonsai_scout_helpers.py` with:

```
def _json_safe(value):
    """Recursively convert NumPy objects to plain Python JSON-safe types."""
    if isinstance(value, np.ndarray):
        return value.tolist()
    if isinstance(value, np.generic):
        return value.item()
    if isinstance(value, dict):
        return {key: _json_safe(val) for key, val in value.items()}
    if isinstance(value, (list, tuple)):
        return [_json_safe(item) for item in value]
    return value
```

