### PR TITLE
Print optRes.nit iteration count for both optTimes() calls in core_calc

### DIFF
--- a/bonsai/bonsai_main.py
+++ b/bonsai/bonsai_main.py
@@ -382,11 +382,13 @@ if args.step in ['core_calc', 'all']:
                                                       get_cell_info=False, all_ranks=False, rel_to_results=True)
 
             startOptTimes = time.time()
-            optTimes = scData.tree.optTimes(verbose=True, singleProcess=True, mem_friendly=True, maxiter=100)
+            optTimes, opt_times_nit = scData.tree.optTimes(verbose=True, singleProcess=True, mem_friendly=True,
+                                                           maxiter=100, return_diagnostics=True)
 
             if (scData is not None) and (scData.tree is not None):
                 scData.tree.root.clear_memory()
             mp_print("Optimization of diffusion times took " + str(time.time() - startOptTimes) + " seconds.")
+            mp_print("Optimization of diffusion times converged in " + str(opt_times_nit) + " iterations.")
             scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
                                                                   loglikVarCorr=scData.metadata.loglikVarCorr)
             mp_print("Loglikelihood of inferred tree after optimising diffusion times: " + str(scData.metadata.loglik))
@@ -536,9 +538,11 @@ if args.step in ['core_calc', 'all']:
 
         startOptTimes = time.time()
         mp_print("Starting a final optimization of diffusion times.")
-        optTimes = scData.tree.optTimes(verbose=True, mem_friendly=True, maxiter=100, singleProcess=True)
+        optTimes, opt_times_nit = scData.tree.optTimes(verbose=True, mem_friendly=True, maxiter=100,
+                                                       singleProcess=True, return_diagnostics=True)
         new_opt_times = scData.tree.test_for_zero_times(verbose=True, mem_friendly=True, singleProcess=True)
         mp_print("Optimization of diffusion times took " + str(time.time() - startOptTimes) + " seconds.")
+        mp_print("Optimization of diffusion times converged in " + str(opt_times_nit) + " iterations.")
         scData.metadata.loglik = scData.tree.calcLogLComplete(mem_friendly=True,
                                                               loglikVarCorr=scData.metadata.loglikVarCorr)
         if (scData is not None) and (scData.tree is not None):

--- a/bonsai/bonsai_treeHelpers.py
+++ b/bonsai/bonsai_treeHelpers.py
@@ -3432,13 +3432,19 @@ class Tree:
         return - loglik, np.sum(- grad * t)
 
     # Used
-    def optTimes(self, verbose=False, singleProcess=False, mem_friendly=True, maxiter=1e6, tol=1e-6):
+    def optTimes(self, verbose=False, singleProcess=False, mem_friendly=True, maxiter=1e6, tol=1e-6,
+                return_diagnostics=False):
         """
 
         :param verbose:
         :param singleProcess: This boolean variable determines whether many processes work together to calculate such
         that mergeChildrenUB can again be parallelized, or whether different processes are doing different instances
         of this function.
+        :param return_diagnostics: if True, also return scipy.optimize.minimize's own iteration count
+        (optRes.nit) as a second return value, for comparing convergence against the C++ port's
+        nlopt::opt::get_numevals(). Default False keeps every existing caller's return value unchanged
+        (a bare dict), since this is the same joint time-optimisation call used throughout the codebase,
+        not just in bonsai_main.py.
         :return:
         """
         if mpi_wrapper.is_first_process() or singleProcess:
@@ -3450,16 +3456,22 @@ class Tree:
                               options={'disp': False, 'maxiter': maxiter}, jac=True, bounds=bounds)
             optTimes = np.exp(optRes.x)
             optTimes[optTimes < (1e-6 + 1e-6)] = 0.
+            num_iterations = optRes.nit
         else:
             optTimes = None
             nodeInds = None
+            num_iterations = None
         if not singleProcess:
             nodeInds = mpi_wrapper.bcast(nodeInds, root=0)
             optTimes = mpi_wrapper.bcast(optTimes, root=0)
+            if return_diagnostics:
+                num_iterations = mpi_wrapper.bcast(num_iterations, root=0)
 
         optTimes = dict(zip(nodeInds, optTimes))
         self.root.assignTs(optTimes)
         self.root.getLtqsComplete(mem_friendly=True)
+        if return_diagnostics:
+            return optTimes, num_iterations
         return optTimes
 
     # Used


### PR DESCRIPTION
Tree.optTimes() gains an opt-in return_diagnostics=True that also returns scipy.optimize.minimize's own optRes.nit, alongside the existing dict of times (default behaviour/return value unchanged for every other caller). bonsai_main.py's two core_calc call sites use it to print "Optimization of diffusion times converged in N iterations." next to the existing timing line