### PR TITLE
Diagnostics for cell data going missing around merges/reloads

### DIFF
--- a/bonsai/bonsai_dataprocessing.py
+++ b/bonsai/bonsai_dataprocessing.py
@@ -355,6 +355,17 @@ class SCData:
         mpiRank = mpi_wrapper.get_process_rank()
         if cleanup_tree:
             self.tree.root.mergeZeroTimeChilds()
+            # Non-zero ranks are sometimes deliberately reloaded with topology only (see the
+            # all_ranks=False reloads in bonsai_main.py, "not the data"), so they don't have real
+            # ltqs/ltqsVars on every leaf. getLtqsComplete needs that data on every leaf it visits,
+            # so only run it on the ranks that actually have it -- same gating as the write below.
+            if (mpiRank == 0) or all_ranks:
+                mp_print("storeTreeInFolder: rank %d computing full tree ltqs (mpiRank==0 or all_ranks=%r)" %
+                         (mpiRank, all_ranks), ALL_RANKS=True)
+                self.tree.root.getLtqsComplete(mem_friendly=bs_glob.mem_friendly)
+            else:
+                mp_print("storeTreeInFolder: rank %d skipping getLtqsComplete (topology-only tree)" % mpiRank,
+                         ALL_RANKS=True)
             self.cleanup_node_inds()
             # self.tree.root.renumberNodes(change_node_inds=False)
             self.tree.nNodes = bs_glob.nNodes
@@ -2570,6 +2581,20 @@ def load_data_for_tree(scData, tree_folder, vertind_to_node, get_all_data=True, 
                         node.ltqs = ltqs_cg[vert_ind, :]
                         node.setLtqsVarsOrW(ltqsVars=ltqsVars_cg[vert_ind, :])
                     node.isCell = node.nodeId in cell_id_set
+                n_bad = 0
+                for check_vert_ind, check_node in vertind_to_node.items():
+                    if check_node.getLtqsVars(mem_friendly=True) is None:
+                        n_bad += 1
+                        if n_bad <= 5:
+                            mp_print("load_data_for_tree: node has no ltqsVars right after loading -- "
+                                     "vert_ind=%r, nodeInd=%r, nodeId=%r, isLeaf=%r, isCell=%r, "
+                                     "raw_ltqsVars_row=%r" %
+                                     (check_vert_ind, check_node.nodeInd, check_node.nodeId, check_node.isLeaf,
+                                      check_node.isCell, ltqsVars_cg[check_vert_ind, :]),
+                                     WARNING=True, ALL_RANKS=True)
+                if n_bad:
+                    mp_print("load_data_for_tree: %d of %d nodes had no ltqsVars right after loading" %
+                             (n_bad, bs_glob.nNodes), WARNING=True, ALL_RANKS=True)
                 del ltqs_cg
                 del ltqsVars_cg
                 gc.collect()

--- a/bonsai/bonsai_dataprocessing.py
+++ b/bonsai/bonsai_dataprocessing.py
@@ -355,10 +355,9 @@ class SCData:
         mpiRank = mpi_wrapper.get_process_rank()
         if cleanup_tree:
             self.tree.root.mergeZeroTimeChilds()
-            # Non-zero ranks are sometimes deliberately reloaded with topology only (see the
-            # all_ranks=False reloads in bonsai_main.py, "not the data"), so they don't have real
+            # Processes with non-zero rank sometimes reload the tree with topology only, so they don't have
             # ltqs/ltqsVars on every leaf. getLtqsComplete needs that data on every leaf it visits,
-            # so only run it on the ranks that actually have it -- same gating as the write below.
+            # so only run it on the ranks that have it
             if (mpiRank == 0) or all_ranks:
                 mp_print("storeTreeInFolder: rank %d computing full tree ltqs (mpiRank==0 or all_ranks=%r)" %
                          (mpiRank, all_ranks), ALL_RANKS=True)

--- a/bonsai/bonsai_treeHelpers.py
+++ b/bonsai/bonsai_treeHelpers.py
@@ -794,10 +794,8 @@ class TreeNode:
         for ind, child in enumerate(self.childNodes):
             if not child.isLeaf:
                 child.mergeZeroTimeChilds()
-                # Cell nodes represent a real measured cell, not just an inferred ancestor position.
-                # Collapsing one away would discard that cell's data from the computation, so only
-                # non-cell ancestors are eligible for merging (matches deleteParentsWithOneChild and
-                # mergeNodes, which both guard on isCell for the same reason).
+                # Cell nodes represent a real measurement, not an inferred ancestor position.
+                # We do not delete these nodes as it would discard that cell's data.
                 if (child.tParent == 0) and (not child.isCell):
                     childrenToBeAdded += child.childNodes
                     childIndsToBeDeleted.append(ind)

--- a/bonsai/bonsai_treeHelpers.py
+++ b/bonsai/bonsai_treeHelpers.py
@@ -794,9 +794,11 @@ class TreeNode:
         for ind, child in enumerate(self.childNodes):
             if not child.isLeaf:
                 child.mergeZeroTimeChilds()
-                if child.tParent == 0:
-                    if child.isCell and (not self.isCell):
-                        self.nodeId = child.nodeId
+                # Cell nodes represent a real measured cell, not just an inferred ancestor position.
+                # Collapsing one away would discard that cell's data from the computation, so only
+                # non-cell ancestors are eligible for merging (matches deleteParentsWithOneChild and
+                # mergeNodes, which both guard on isCell for the same reason).
+                if (child.tParent == 0) and (not child.isCell):
                     childrenToBeAdded += child.childNodes
                     childIndsToBeDeleted.append(ind)
                     child.parentNode = None
@@ -2512,6 +2514,10 @@ class TreeNode:
                 #                                                   self.childNodes[
                 #                                                       nodeIndToChildInd[nodeInd2]].celltype))
 
+        if addAsChild and newNode.isLeaf:
+            mp_print("mergeNodes: demoting a LEAF to an ancestor -- nodeInd=%r, nodeId=%r, isCell=%r, "
+                     "tParent=%r" % (newNode.nodeInd, newNode.nodeId, newNode.isCell, newNode.tParent),
+                     WARNING=True, ALL_RANKS=True)
         newNode.isLeaf = False
         delInds = []
         del_node_inds = []
@@ -2534,6 +2540,11 @@ class TreeNode:
         for nodeInd in gchildInds:
             ind = nodeIndToChildInd[nodeInd]
             child = self.childNodes[ind]
+            if child.isCell and (child.getLtqsVars(mem_friendly=True) is None):
+                mp_print("mergeNodes: cell child about to be attached with no ltqsVars -- nodeInd=%r, "
+                         "nodeId=%r, isLeaf=%r, newAncestor=%r" %
+                         (child.nodeInd, child.nodeId, child.isLeaf, newNode.nodeInd),
+                         WARNING=True, ALL_RANKS=True)
             delInds.append(ind)
             del_node_inds.append(nodeInd)
             newNode.childNodes.append(child)
@@ -5253,7 +5264,16 @@ def findNodeLtqsGivenLeafs(childNodes=None, ltqs_gi=None, ltqsVars_gi=None, t_i=
         if return_wbar_gi:
             wbar_gi = np.zeros(bs_glob.nGenes, len(childNodes))
         for cInd, child in enumerate(childNodes):
-            wbar_g = 1 / (child.getLtqsVars(mem_friendly=True) + child.tParent)
+            child_ltqsVars = child.getLtqsVars(mem_friendly=True)
+            if (child_ltqsVars is None) or (child.tParent is None):
+                mp_print("findNodeLtqsGivenLeafs: bad child before divide -- "
+                         "nodeInd=%r, vert_ind=%r, nodeId=%r, isLeaf=%r, isCell=%r, "
+                         "ltqsVars=%r, tParent=%r, parentNode.nodeInd=%r" %
+                         (child.nodeInd, child.vert_ind, child.nodeId, child.isLeaf, child.isCell,
+                          child_ltqsVars, child.tParent,
+                          child.parentNode.nodeInd if child.parentNode else None),
+                         WARNING=True, ALL_RANKS=True)
+            wbar_g = 1 / (child_ltqsVars + child.tParent)
             if return_wbar_gi:
                 wbar_gi[:, cInd] = wbar_g
             W_g += wbar_g


### PR DESCRIPTION
Adds mp_print(WARNING=True, ALL_RANKS=True) diagnostics wherever a cell node's ltqsVars unexpectedly comes back None, plus the isCell/tParent fix that motivated looking there:

- TreeNode.mergeZeroTimeChilds: only merge away a zero-tParent child if it isn't a cell (a cell represents a real measured cell, not just an inferred ancestor position -- collapsing one away discarded its data; matches the isCell guard mergeNodes/deleteParentsWithOneChild already use).
- TreeNode.mergeNodes: warn when a leaf is demoted to an ancestor, and when a cell child is about to be attached with no ltqsVars.
- findNodeLtqsGivenLeafs: warn (with node identity) before a None ltqsVars or None tParent would otherwise divide-by-None silently.
- SCData.storeTreeInFolder: only call getLtqsComplete on ranks that actually have real per-leaf data (topology-only reloads from all_ranks=False don't), logging which case each rank hit.
- load_data_for_tree: count and warn about nodes with no ltqsVars right after loading, instead of letting it surface later as a confusing divide-by-None somewhere downstream.